### PR TITLE
Add doctrine/annotations dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=7.1.3",
         "jms/serializer": "^1 | ^2 | ^3",
         "ramsey/uuid": "^3 | ^4",
-        "symfony/mime": "^4.3 | ^5"
+        "symfony/mime": "^4.3 | ^5",
+        "doctrine/annotations": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7 | ^8 | ^9"


### PR DESCRIPTION
Some methods have been removed in 2.0 version doctrine/annotations:  
https://github.com/doctrine/annotations/pull/468/files  

But it is used in current codebase (e.g. AnnotationRegistry::registerUniqueLoader)  

Therefore, it is necessary to correct the version to 1.*