### PR TITLE
Loosen version requirement of symfony/mime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "allure-framework/allure-php-api",
-    "keywords":["PHP", "report", "allure", "api"],
+    "keywords": ["PHP", "report", "allure", "api"],
     "description": "Allure PHP commons",
     "homepage": "https://allurereport.org/",
     "license": "Apache-2.0",
@@ -19,7 +19,7 @@
         "php": ">=7.1.3",
         "jms/serializer": "^1 | ^2 | ^3",
         "ramsey/uuid": "^3 | ^4",
-        "symfony/mime": "^4.3 | ^5",
+        "symfony/mime": "^4.3 | ^5 | ^6 | ^7",
         "doctrine/annotations": "1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Loosen version requirement of symfony/mime. Allows using version 6 or 7.